### PR TITLE
Bugfix for using face_detection.launch with OpenCV4 and ROS Noetic

### DIFF
--- a/launch/face_detection.launch
+++ b/launch/face_detection.launch
@@ -1,9 +1,8 @@
 <launch>
   <arg name="node_name" default="face_detection" />
-  <arg name="use_opencv3" default="false" />
   <arg name="use_opencv3_1" default="false" />
   <arg name="use_opencv3_2" default="false" />
-  <arg name="use_opencv3_3" default="$(arg use_opencv3)" />
+  <arg name="use_opencv3_3" default="false" />
   <arg name="use_opencv4" default="false" />
 
   <arg name="image" default="image" doc="The image topic. Should be remapped to the name of the real image topic." />
@@ -29,9 +28,9 @@
   <arg if="$(arg use_opencv4)"
        name="eyes_cascade_name" default="/usr/share/opencv4/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye dtection cascade Filename" />
 
-  <arg unless="$(arg use_opencv3)"
+  <arg unless="$(eval arg('use_opencv3_1') or arg('use_opencv3_2') or arg('use_opencv3_3') or arg('use_opencv4'))"
        name="face_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml" doc="Face dtection cascade Filename" />
-  <arg unless="$(arg use_opencv3)"
+  <arg unless="$(eval arg('use_opencv3_1') or arg('use_opencv3_2') or arg('use_opencv3_3') or arg('use_opencv4'))"
        name="eyes_cascade_name" default="/usr/share/opencv/haarcascades/haarcascade_eye_tree_eyeglasses.xml" doc="Eye dtection cascade Filename" />
 
   <!-- face_detection.cpp -->


### PR DESCRIPTION
The default values for 'face_cascade_name' and 'eyes_cascade_name' were always set to their default values except if use_opencv3 was true. Thus, I was not able to use this launch-script with OpenCV4 on Ubuntu 20.04 with ROS Noetic.

As a fix I check whether the arguments are set to a specific OpenCV version and use default values only if this is not the case.